### PR TITLE
Add optional pre-code field to write code question

### DIFF
--- a/bot/questions.json
+++ b/bot/questions.json
@@ -15,14 +15,14 @@
     },
     {
       "type": "write_code",
-      "question": "Write a list comprehension that squares all numbers in the list `numbers = [1, 2, 3, 4, 5]` and stores the result in a list called `squares`.",
+      "question": "Write a list comprehension that squares all numbers in the list `numbers = [1, 2, 3, 4, 5]`.",
       "hints": [
         "You can use the expression `x ** 2` to square a number `x`.",
-        "Remember to store the result in a list called `squares`, rather than the original `numbers` list.",
         "The list comprehension should iterate over each number in the list `numbers`.",
         "The list comprehension should have the form `[expression for item in iterable]`.",
         "The `expression` should square the `item`."
       ],
+      "pre_code": "numbers=[1,2,3,4,5]\nsquares=",
       "test_cases": [
         {
           "input": "squares",
@@ -149,7 +149,7 @@
     },
     {
       "type": "write_code",
-      "question": "Implement a function `multiply` that can take either two or three arguments. If two arguments are provided, it should return their product. If three arguments are provided, it should return their product plus the third argument.",
+      "question": "Implement a function `multiply` that can take either two or three arguments. If two arguments are provided, it should return their product. If three arguments are provided, it should return the product of all three numbers.",
       "hints": [
         "You can use default argument values to handle the case where the third argument is not provided.",
         "The function should return the product of the first two arguments plus the third argument, if it exists."
@@ -161,7 +161,7 @@
         },
         {
           "input": "multiply(2, 3, 4)",
-          "output": "10"
+          "output": "24"
         },
         {
           "input": "multiply(-2, 5)",
@@ -185,7 +185,7 @@
         "b": "TypeError: add() missing 1 required positional argument: 'c'",
         "c": "TypeError: add() takes 3 positional arguments but 2 were given"
       },
-      "answer": "c"
+      "answer": "b"
     }
   ]
 }

--- a/bot/questions.py
+++ b/bot/questions.py
@@ -230,6 +230,7 @@ class WriteCodeQuestion(Question):
 
     In the JSON data for a write code question, the following additional fields must be included:
     {
+        "pre_code": "squares = ",  # Assign user's one-liner to variable squares
         "test_cases": [
             ["add(1, 2)", "3"],
             ["add(-1, 3)", "2"],
@@ -240,15 +241,27 @@ class WriteCodeQuestion(Question):
     is the expected output. The input and output should be strings that can be evaluated as Python code. For example,
     if the expected value is the string literal 'hello', it should be enclosed in quotes: "'hello'".
 
+    The `pre_code` code will be insert right before the user's code. No newline will be inserted between it and the
+    user's code, which enables assigning the user's code output to a variable. If you do want to separate the pre_code
+    from the user's code, please end pre_code with a line break (\\n). For example: `"pre_code": "import inspect\\n"`.
+    `pre_code` is an optional field.
+
     The question should clearly state what the expected name of the function to be created is. For example, if the
     question is to create a function that adds two numbers, the question should state that the function should be
     named `add`. If the function is not named correctly, the tests will fail.
     """
 
-    def __init__(self, question: str, hints: list[str], test_cases: list[dict[str, str]]) -> None:
+    def __init__(
+        self,
+        question: str,
+        hints: list[str],
+        test_cases: list[dict[str, str]],
+        pre_code: str | None = None,
+    ) -> None:
         self.type = "write_code"
         self.question = question
         self.hints = hints
+        self.pre_code = pre_code
         self.unlocked_hints = 0
         self.test_cases = test_cases
 
@@ -293,6 +306,7 @@ class WriteCodeQuestion(Question):
             test_strings.append(self._get_assert_equal_string(input, output))
         return (
             "import unittest\n"  # Import unittest module
+            + ("" if self.pre_code is None else self.pre_code)  # Adds code to run before user code, no newline after
             + user_code.expandtabs(2)  # Insert user code. Tabs -> spaces for consistency with test code
             + "\nclass Test(unittest.TestCase):\n"  # Setup test class
             + " def test_cases(self):"  # Setup test method


### PR DESCRIPTION
Allows for 2 main new features:
- Executing code, like imports and assignments, before the user's code is run. This allows us to provide variables or modules for the user to use in their solution
- Assigning user's output to a variable. Since we need to assign the user's output to a variable, function or class, in order to test it with assertequals in a unit test, the user previously couldn't submit one-line solutions without assigning to a variable. For example, when asking the user to write a list comprehension, we now can add a pre_code like `out=`, which will assign the user's code to the out variable, allowing us to test the value of it