### PR TITLE
Remove valueerror when loading levels multiple times

### DIFF
--- a/bot/main.py
+++ b/bot/main.py
@@ -132,8 +132,10 @@ async def on_ready() -> None:
     except discord.DiscordException as e:
         print(f"Err: {e}")
 
-    register_all_levels()
-    print("Loaded levels:", ", ".join(str(level.id) for level in Controller().levels))
+
+# Load levels
+register_all_levels()
+print("Loaded levels:", ", ".join(str(level.id) for level in Controller().levels))
 
 
 # Start the bot


### PR DESCRIPTION
When the bot is temporarily disconnected, but the session still remains, when the bot is reconnected  will run a second time. Since load levels was done inside on_ready, it would load the levels a second time. Since the levels have already been added, it raised a ValueError. This commit changes where the levels are loaded, to not have this issue